### PR TITLE
Fix matter generation

### DIFF
--- a/base/src/main/kotlin/dev/nathanpb/dml/enums/MatterType.kt
+++ b/base/src/main/kotlin/dev/nathanpb/dml/enums/MatterType.kt
@@ -17,6 +17,6 @@ enum class MatterType(id: String, color: Formatting) {
 
     val text: Text = Text.translatable("modelType.${MOD_ID}.${id}").formatted(color)
 
-    val matter: Item? = getItemFromRegistry(identifier("${id}_matter"))
+    val matter: Item? by lazy { getItemFromRegistry(identifier("${id}_matter")) }
 
 }


### PR DESCRIPTION
Currently, matter generation is broken due to the `matter` field being initialized too early in the `MatterType` enum.

![Air 2](https://i.imgur.com/omKK8jv.png)
![Air](https://i.imgur.com/WPcLIBq.png)

The fix, which turns out to be simple, is to make use of kotlin's [lazy](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/lazy.html) to let the game initialize the field when it's first used, then value gets cached afterwards. 